### PR TITLE
#188168 アラート停止方法が手動停止の設定でカメラ切断等の録画停止条件のアラート警告時にスマホ電源ボタン押すとバイブ動作が停止する

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/androidTest/java/com/example/androidlifecycle/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/androidlifecycle/ExampleInstrumentedTest.kt
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.example.androidlifecycle", appContext.packageName)
+        assertEquals("com.example.androidlifecycle ", appContext.packageName)
     }
 }


### PR DESCRIPTION
[内容]
isReceiverRegistered と mSystemEventReceiverの2つの変数を使うのではなく、mSystemEventReceiveのみを使い、そのnullチェックで登録状態を管理する（レビュー項目）

[指摘元]
QA

[影響範囲]
警告音再生

[備考]
-